### PR TITLE
Fix: "heap use after free" reported by address sanitizer

### DIFF
--- a/src/tds/net.c
+++ b/src/tds/net.c
@@ -749,7 +749,6 @@ tds_socket_read(TDSCONNECTION * conn, TDSSOCKET *tds, unsigned char *buf, int bu
 		return 0;
 
 	/* detect connection close */
-	tds_connection_close(conn);
 	tdserror(conn->tds_ctx, tds, len == 0 ? TDSESEOF : TDSEREAD, len == 0 ? 0 : err);
 	return -1;
 }


### PR DESCRIPTION
Fix: heap-use-after-free reported by Address Sanitizer:

```
=================================================================
==nsp_servers==1875306==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d000227330 at pc 0x7fc7636c14f3 bp 0x7fc6fbb40500 sp 0x7fc6fbb404f8
READ of size 8 at 0x60d000227330 thread T78 (nsp.csc.lstm.Ex)
    #0 0x7fc7636c14f2 in bio_read_intern /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_lib.c:297:9
    #1 0x7fc7636c11c1 in BIO_read /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_lib.c:318:11
    #2 0x7fc762c2da9e in ssl3_read_n /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/record/rec_layer_s3.c:310:19
    #3 0x7fc762c35e25 in ssl3_get_record /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/record/ssl3_record.c:210:20
    #4 0x7fc762c324e6 in ssl3_read_bytes /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/record/rec_layer_s3.c:1364:19
    #5 0x7fc762bbf7cd in ssl3_read_internal /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/s3_lib.c:4463:9
    #6 0x7fc762be36f4 in ssl_read_internal /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/ssl_lib.c:1871:16
    #7 0x7fc762be3fc1 in SSL_read /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/ssl_lib.c:1885:11
    #8 0x7fc6ab6ff87d in tds_ssl_read /artifacts/external/freetds/freetds-1.3.13/src/tds/../../include/freetds/tls.h:83:9
    #9 0x7fc6ab6ff7f5 in tds_connection_read /artifacts/external/freetds/freetds-1.3.13/src/tds/net.c:970:10
    #10 0x7fc6ab71b044 in tds_packet_read /artifacts/external/freetds/freetds-1.3.13/src/tds/packet.c:153:8
    #11 0x7fc6ab715950 in tds_connection_network /artifacts/external/freetds/freetds-1.3.13/src/tds/packet.c:404:9
    #12 0x7fc6ab7148b9 in tds_read_packet /artifacts/external/freetds/freetds-1.3.13/src/tds/packet.c:572:4
    #13 0x7fc6ab6a0218 in tds_get_byte /artifacts/external/freetds/freetds-1.3.13/src/tds/read.c:75:7
    #14 0x7fc6ab67c072 in tds_process_tokens /artifacts/external/freetds/freetds-1.3.13/src/tds/token.c:569:12
    #15 0x7fc6ab68a5df in tds_process_simple_query /artifacts/external/freetds/freetds-1.3.13/src/tds/token.c:890:15
    #16 0x7fc6ab61398d in _SQLExecute /artifacts/external/freetds/freetds-1.3.13/src/odbc/odbc.c:3382:8
    #17 0x7fc6ab611cdc in SQLExecute /artifacts/external/freetds/freetds-1.3.13/src/odbc/odbc.c:3599:8
```

Memory freed (look for net.c:752):

```
    #0 0x39d5d2 in free (/server+0x39d5d2) (BuildId: 726d8ae38751f8ce)
    #1 0x7fc7636c0c27 in BIO_free /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_lib.c:154:5
    #2 0x7fc7636c3c7b in BIO_free_all /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_lib.c:761:9
    #3 0x7fc762bdb7df in SSL_free /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/ssl_lib.c:1195:5
    #4 0x7fc6ab7036f5 in tds_ssl_deinit /artifacts/external/freetds/freetds-1.3.13/src/tds/tls.c:1092:3
    #5 0x7fc6ab6fd30b in tds_connection_close /artifacts/external/freetds/freetds-1.3.13/src/tds/net.c:585:2
    #6 0x7fc6ab6ff6d2 in tds_socket_read /artifacts/external/freetds/freetds-1.3.13/src/tds/net.c:752:2
    #7 0x7fc6ab6ff2b0 in tds_goodread /artifacts/external/freetds/freetds-1.3.13/src/tds/net.c:936:10
    #8 0x7fc6ab704216 in tds_pull_func /artifacts/external/freetds/freetds-1.3.13/src/tds/tls.c:174:9
    #9 0x7fc7636c50bd in bread_conv /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_meth.c:123:11
    #10 0x7fc7636c1494 in bio_read_intern /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_lib.c:292:11
    #11 0x7fc7636c11c1 in BIO_read /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/crypto/bio/bio_lib.c:318:11
    #12 0x7fc762c2da9e in ssl3_read_n /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/record/rec_layer_s3.c:310:19
    #13 0x7fc762c35e25 in ssl3_get_record /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/record/ssl3_record.c:210:20
    #14 0x7fc762c324e6 in ssl3_read_bytes /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/record/rec_layer_s3.c:1364:19
    #15 0x7fc762bbf7cd in ssl3_read_internal /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/s3_lib.c:4463:9
    #16 0x7fc762be36f4 in ssl_read_internal /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/ssl_lib.c:1871:16
    #17 0x7fc762be3fc1 in SSL_read /artifacts/external/openssl/linux_pc_64_clang_asan/openssl-3.0.7/ssl/ssl_lib.c:1885:11
    #18 0x7fc6ab6ff87d in tds_ssl_read /artifacts/external/freetds/freetds-1.3.13/src/tds/../../include/freetds/tls.h:83:9
    #19 0x7fc6ab6ff7f5 in tds_connection_read /artifacts/external/freetds/freetds-1.3.13/src/tds/net.c:970:10
    #20 0x7fc6ab71b044 in tds_packet_read /artifacts/external/freetds/freetds-1.3.13/src/tds/packet.c:153:8
    #21 0x7fc6ab715950 in tds_connection_network /artifacts/external/freetds/freetds-1.3.13/src/tds/packet.c:404:9
    #22 0x7fc6ab7148b9 in tds_read_packet /artifacts/external/freetds/freetds-1.3.13/src/tds/packet.c:572:4
    #23 0x7fc6ab6a0218 in tds_get_byte /artifacts/external/freetds/freetds-1.3.13/src/tds/read.c:75:7
    #24 0x7fc6ab67c072 in tds_process_tokens /artifacts/external/freetds/freetds-1.3.13/src/tds/token.c:569:12
    #25 0x7fc6ab68a5df in tds_process_simple_query /artifacts/external/freetds/freetds-1.3.13/src/tds/token.c:890:15
```

This heap-use-after-free causes freetds to segfault when the connection to a MS SQLServer is teared down.


